### PR TITLE
Reset buffer offset and total bytes hashed

### DIFF
--- a/src/main/java/com/github/eprst/murmur3/HashingSink128.java
+++ b/src/main/java/com/github/eprst/murmur3/HashingSink128.java
@@ -28,6 +28,8 @@ public final class HashingSink128 {
   public HashingSink128 reset() {
     h1 = seed & 0x00000000FFFFFFFFL;
     h2 = seed & 0x00000000FFFFFFFFL;
+    bufferOffset = 0;
+    totalBytesHashed = 0;
     return this;
   }
 

--- a/src/test/java/com/github/eprst/murmur3/TestHashingSink.java
+++ b/src/test/java/com/github/eprst/murmur3/TestHashingSink.java
@@ -146,6 +146,25 @@ public class TestHashingSink extends TestCase {
     }
   }
 
+  public void testReset() {
+    RandomHashableGenerator g = new RandomHashableGenerator();
+    Hashable h = g.randomHashable(200);
+
+    int seed = Math.abs(new Random().nextInt());
+
+    HashingSink128 s = new HashingSink128(seed);
+
+    h.sendToHashing(s);
+    MurmurHash3.HashCode128 hc1 = s.finish();
+    String result1 = hc1.toString();
+
+    h.sendToHashing(s);
+    MurmurHash3.HashCode128 hc2 = s.finish();
+    String result2 = hc2.toString();
+
+    assertEquals(result1, result2);
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
Without resetting these fields the hash result is non-deterministic. Resetting them results in the same results as the guava implementation when called multiple times, beforehand it varied after the first call.

Thanks for the great alternative to Guava - we were seeing huge amounts of GC with the Guava version.
